### PR TITLE
Allow any callable to be passed as a processor (L4 branch)

### DIFF
--- a/src/RavenServiceProvider.php
+++ b/src/RavenServiceProvider.php
@@ -37,7 +37,9 @@ class RavenServiceProvider extends ServiceProvider
                 if (is_array($processors)) {
                     foreach ($processors as $process) {
                         // Get callable
-                        if (is_string($process)) {
+                        if (is_callable($process)) {
+                            $callable = $process;
+                        } else if (is_string($process)) {
                             $callable = new $process();
                         } else {
                             throw new \Exception('Raven: Invalid processor');


### PR DESCRIPTION
Without this a closure can't be passed.