### PR TITLE
Pass EventDispatcher to custom Logger

### DIFF
--- a/src/RavenServiceProvider.php
+++ b/src/RavenServiceProvider.php
@@ -64,6 +64,6 @@ class RavenServiceProvider extends ServiceProvider
             return new Client(config('raven'), $app['queue'], $app->environment());
         });
 
-        $this->app->instance('log', new Log($this->app['log']->getMonolog()));
+        $this->app->instance('log', new Log($this->app['log']->getMonolog(), $this->app['log']->getEventDispatcher()));
     }
 }


### PR DESCRIPTION
Dispatcher is required for `fireLogEvent` method to allow for listening to log events.