### PR TITLE
User data processor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,33 @@ Log::error('Oops, Something went wrong', [
 ]);
 ```
 
+User data can alternatively be added to the context of any messages sent via a processor, such as the included `UserDataProcessor`; see below.
+
+#### Included optional processors
+
+##### `UserDataProcessor`
+
+This processor attaches data about the current user to the error report.
+
+```php
+'processors' => [
+    Clowdy\Raven\Processors\UserDataProcessor::class,
+],
+```
+
+Or, to configure the `UserDataProcessor` object:
+
+```php
+'processors' => [
+    new Clowdy\Raven\Processors\UserDataProcessor([
+        'only' => ['id', 'username', 'email'], // This is ['id'] by default; pass [] or null to include all fields
+        'appends' => ['normallyHiddenProperty'],
+    ]),
+],
+```
+
+See the `UserDataProcessor` source for full details.
+
 ## Credits
 
 This package was inspired [rcrowe/Raven](https://github.com/rcrowe/Raven).

--- a/src/Processors/UserDataProcessor.php
+++ b/src/Processors/UserDataProcessor.php
@@ -26,6 +26,7 @@ class UserDataProcessor
      * @var array
      */
     protected $options = [
+        'appends' => [],
         'except' => [],
         'only' => [
             'id',
@@ -36,6 +37,7 @@ class UserDataProcessor
      * Make a new UserDataProcessor.
      *
      * Options:
+     * - array 'appends': extra fields from the user to include
      * - array 'except': fields from the user not to include
      * - array 'only': the only fields from the user to include, or null to
      *                 include all fields (other than those removed by 'except')
@@ -68,6 +70,10 @@ class UserDataProcessor
 
             if (! empty($this->options['only'])) {
                 $data = array_only($data, $this->options['only']);
+            }
+
+            foreach ($this->options['appends'] as $key) {
+                $data[$key] = $user->{$key};
             }
         }
 

--- a/src/Processors/UserDataProcessor.php
+++ b/src/Processors/UserDataProcessor.php
@@ -10,8 +10,8 @@ use Illuminate\Support\Facades\Auth;
  *
  * The model's `toArray` method is used to get the user data. This is provided
  * by Eloquent and can be overridden to provide extra fields or to remove
- * fields. Fields can also be removed in Eloquent by populating the `$hidden`
- * property.
+ * fields. Fields can also be removed and added in Eloquent by populating the
+ * `$hidden` and `$appends` properties.
  *
  * The fields retrieved from `toArray` are then filtered with any options passed
  * to this processor's constructor before being attached to the error report.
@@ -41,8 +41,8 @@ class UserDataProcessor
      *                 include all fields (other than those removed by 'except')
      *
      * Note that rather than using these options it may be preferable in certain
-     * cases to use the User model's `$hidden` property or overriding its
-     * `toArray` method.
+     * cases to use the User model's `$hidden` and `$appends` properties, or
+     * overriding its `toArray` method.
      *
      * @param array $options
      */

--- a/src/Processors/UserDataProcessor.php
+++ b/src/Processors/UserDataProcessor.php
@@ -16,9 +16,9 @@ use Illuminate\Support\Facades\Auth;
  * The fields retrieved from `toArray` are then filtered with any options passed
  * to this processor's constructor before being attached to the error report.
  *
- * If no user is logged in, the data `['id' => null]` is still attached to the
- * error object, to differentiate a case where no data on the current user is
- * available from a case where it is known that no user is logged in.
+ * By default only the 'id' field from the user is attached; pass null or an
+ * empty array as the 'only' option to override this, or configure otherwise as
+ * you see fit.
  */
 class UserDataProcessor
 {

--- a/src/Processors/UserDataProcessor.php
+++ b/src/Processors/UserDataProcessor.php
@@ -77,7 +77,19 @@ class UserDataProcessor
             }
         }
 
-        $record['context']['user'] = array_merge($data, array_get($record, 'context.user', []));
+        // Nest all but the particular keys Sentry treats specially in a 'data'
+        // substructure; see
+        // https://github.com/getsentry/sentry/blob/e7a295784f10a296ace7aa98e1b7216328feac5d/src/sentry/interfaces/user.py#L31
+        $topLevel = [
+            'id',
+            'username',
+            'email',
+            'ip_address',
+        ];
+        $userArray = array_only($data, $topLevel);
+        $userArray['data'] = array_except($data, $topLevel);
+
+        $record['context']['user'] = array_merge($userArray, array_get($record, 'context.user', []));
 
         return $record;
     }

--- a/src/Processors/UserDataProcessor.php
+++ b/src/Processors/UserDataProcessor.php
@@ -55,7 +55,7 @@ class UserDataProcessor
      * Run the processor: attach user data to a Monolog record.
      *
      * @param array $record Monolog record
-     * 
+     *
      * @return array $record
      */
     public function __invoke(array $record)


### PR DESCRIPTION
This is a collection of patches which improve the user data processor, both in documentation and features.

The main changes other than documentation are these:

- Add an `appends` option, which allows extra fields from the user to be added, even if they were not part of the user object's `toArray` return value. This is sometimes useful to include a field which is useful when debugging errors but which is not normally needed when getting data about a user, for example when sending it as JSON via ajax responses.
- Change how the data is passed to Sentry. Sentry shows only particular user data keys (`id`, `username`, `email`, `ip_address`) and treats them specially (giving them formatted names and a Gravatar for email address). It doesn't show any other user data unless the values are part of a `data` substructure. This patch makes all of the passed fields visible in Sentry.