### PR TITLE
Add locale processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ Or, to configure the `UserDataProcessor` object:
 
 See the `UserDataProcessor` source for full details.
 
+##### `LocaleProcessor`
+
+This processor attaches to the error report the current application locale as a tag.
+
+```php
+'processors' => [
+    Clowdy\Raven\Processors\LocaleProcessor::class,
+],
+```
+
 ## Credits
 
 This package was inspired [rcrowe/Raven](https://github.com/rcrowe/Raven).

--- a/src/Processors/LocaleProcessor.php
+++ b/src/Processors/LocaleProcessor.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Clowdy\Raven\Processors;
+
+use Illuminate\Support\Facades\App;
+
+/**
+ * This processor adds the current locale to an outgoing error report as a tag.
+ */
+class LocaleProcessor
+{
+    /**
+     * Run the processor: attach locale tag to a Monolog record
+     *
+     * @param array $record Monolog record
+     * @return array $record
+     */
+    public function __invoke(array $record)
+    {
+        $record['extra']['tags']['locale'] = $this->getLocale();
+        return $record;
+    }
+
+    /**
+     * Get the locale
+     *
+     * @return string
+     */
+    public function getLocale()
+    {
+        return App::getLocale();
+    }
+}


### PR DESCRIPTION
This processor adds a tag 'locale' with the app's current locale to an outgoing report.