### PR TITLE
Add 'release' example option to config file

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -92,7 +92,7 @@ return [
     | instance. For more information about the possible values check
     | out: https://github.com/getsentry/raven-php
     |
-    | Example: "name", "tags", "trace", "timeout", "exclude", "extra", ...
+    | Example: "name", "release", "tags", "trace", "timeout", "exclude", "extra", ...
     |
     */
     'options' => [],


### PR DESCRIPTION
This is the recommended place to put an application version string; this serves as a handy reminder.

See the comments on https://github.com/getsentry/raven-js/pull/511